### PR TITLE
Make TUI the default when no command is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ This project supports modern Python packaging with `pyproject.toml`.
 
 ## Usage
 
-### Launch Interactive TUI
+### Launch Interactive TUI (Default)
+
+```sh
+cm
+```
+
+The TUI launches automatically when no command is specified. You can also explicitly launch it with:
 
 ```sh
 cm tui

--- a/connmanager/main.py
+++ b/connmanager/main.py
@@ -22,7 +22,8 @@ def parse_args() -> argparse.ArgumentParser:
     parser.add_argument(
         "-d", "--debug", action="store_true", help="Enable debug logging."
     )
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command", required=False, 
+                                       help="Available commands (defaults to 'tui' if none specified)")
 
     subparsers.add_parser("add", help='Add a new connection. Can be shortened to "a".')
 
@@ -96,9 +97,9 @@ def main() -> None:
     """
     Main entry point for the CLI tool. Handles argument parsing, logging, and command dispatch.
     """
+    # If no arguments provided, default to TUI
     if len(sys.argv) < 2:
-        logger.error("No command provided. Use -h or --help for usage information.")
-        sys.exit(1)
+        sys.argv.append("tui")
 
     mapped_args = map_shortened_commands(sys.argv[1:])
     parser = parse_args()
@@ -112,26 +113,28 @@ def main() -> None:
     db = DatabaseConnection(db_path)
     manager = ConnectionService(db)
 
-    if args.command.casefold() == "add":
+    # Default to TUI if no command specified
+    command = args.command or "tui"
+    
+    if command.casefold() == "add":
         manager.add_connection()
-    elif args.command.casefold() == "tui":
+    elif command.casefold() == "tui":
         connection_requested = run_tui(manager)
         if connection_requested:
-            # User selected a connection to connect to, execute it
             manager.connect_to_alias_or_id(connection_requested)
-    elif args.command == "edit":
+    elif command == "edit":
         manager.edit_connection(args.alias_or_id)
-    elif args.command.casefold() == "delete":
+    elif command.casefold() == "delete":
         manager.delete_connection(args.alias_or_id)
-    elif args.command.casefold() == "list":
+    elif command.casefold() == "list":
         manager.get_connections_summary(args.protocol_or_tag)
-    elif args.command.casefold() == "search":
+    elif command.casefold() == "search":
         manager.search_connections(args.text)
-    elif args.command.casefold() == "connect":
+    elif command.casefold() == "connect":
         manager.connect_to_alias_or_id(args.alias_or_id)
-    elif args.command == "import":
+    elif command == "import":
         manager.import_connections(args.json_file)
-    elif args.command == "export":
+    elif command == "export":
         manager.export_connections(args.json_file)
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Running 'cm' with no arguments now launches the TUI automatically
- More user-friendly and modern CLI behavior
- Help still available with 'cm --help' or 'cm -h'
- All existing commands continue to work as before
- Update README to highlight new default TUI behavior
- Follows pattern of modern CLI tools (git, docker, etc.)

Benefits:
- Better discoverability for new users
- Faster workflow - just type 'cm' to start
- Shows the visual interface immediately
- More intuitive than requiring 'cm tui' every time